### PR TITLE
feat(generate): immutable config object

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -92,12 +92,12 @@ function _generate({
       finalConfig =
         (path ? esmAndTsDefaultWithPath({ path, encoding }) : esmAndTsDefault) +
         envConfig +
-        '};\n';
+        '});\n';
     } else {
       finalConfig =
         (path ? cjsDefaultWithPath({ path, encoding }) : cjsDefault) +
         envConfig +
-        '};\n';
+        '});\n';
     }
   } else {
     for (const finalKey in parsedData) {
@@ -110,7 +110,7 @@ function _generate({
       ? esmAndTsDefaultWithPath({ path, encoding })
       : esmAndTsDefault;
 
-    finalConfig = defaultTemplate + envConfig + '};\n';
+    finalConfig = defaultTemplate + envConfig + '});\n';
   }
 
   writeFileSync(outPath, finalConfig);

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -6,28 +6,28 @@ type WithPath = {
 const esmAndTsDefault = `import { register } from 'neoenv';
 register();
 
-export const envConfig = {
+export const envConfig = Object.freeze({
 `;
 
 function esmAndTsDefaultWithPath({ path, encoding }: WithPath): string {
   return `import { register } from 'neoenv';
 register({ path: '${path}', encoding: '${encoding}' });
 
-export const envConfig = {
+export const envConfig = Object.freeze({
 `;
 }
 
 const cjsDefault = `const { register } = require('neoenv');
 register();
 
-exports.envConfig = {
+exports.envConfig = Object.freeze({
 `;
 
 function cjsDefaultWithPath({ path, encoding }: WithPath): string {
   return `const { register } = require('neoenv');
 register({ path: '${path}', encoding: '${encoding}' });
 
-exports.envConfig = {
+exports.envConfig = Object.freeze({
 `;
 }
 


### PR DESCRIPTION
Use the `Object.freeze` method to make our config object immutable so that users can't modify the values.

For TypeScript it will throw an error

> Cannot assign to 'CLOUDINARY_API_KEY' because it is a read-only property

For JavaScript, the values won't get changed even if we try to reassign them with new values.

Fixes #1

Signed-off-by: Niloy Sikdar <niloysikdar30@gmail.com>